### PR TITLE
CI: Boosted up for latest Tools

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,40 +1,75 @@
+#                     WARNING -> DO NOT BLINDLY COPY THIS FILE, DOING SO MAY LEAD TO DETERIORATION OF YOUR PROJECT
+
 # This file is a template, and might need editing before it works on your project.
 # Read more about this script on this blog post https://about.gitlab.com/2018/10/24/setting-up-gitlab-ci-for-android-projects/, by Jason Lenny
 # If you are interested in using Android with FastLane for publishing take a look at the Android-Fastlane template.
 
+
+#  This tells GitLab Runners (the things that are executing our build) what Docker image to use
 image: openjdk:8-jdk
+#This Docker image (openjdk:8-jdk) works perfectly for our use case, as it is just a barebones installation of Debian with Java pre-installed.
 
 variables:
+
+  # ANDROID_COMPILE_SDK is the version of Android you're compiling with.
+  # It should match compileSdkVersion.
   ANDROID_COMPILE_SDK: "29"
+
+  # ANDROID_BUILD_TOOLS is the version of the Android build tools you are using.
+  # It should match buildToolsVersion.
   ANDROID_BUILD_TOOLS: "29.0.3"
+
+  # It's what version of the command line tools we're going to download from the official site.
+  # Official Site-> https://developer.android.com/studio/index.html
+  # There, look down below at the cli tools only, sdk tools package is of format:
+  #        commandlinetools-os_type-ANDROID_SDK_TOOLS_latest.zip
+  # when I modified the script for my project, it was which is written down below
   ANDROID_SDK_TOOLS: "6514223"
 
+# Packages installation before running script
 before_script:
   - apt-get --quiet update --yes
   - apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1
+
+  #Setup path as android_home for moving/exporting the downloaded sdk into it
   - export ANDROID_HOME=${PWD}android-home
   - install -d $ANDROID_HOME
+
+  #  Here we are installing androidSDK tools from official source,
+  #  (the key thing here is the url from where you are downloading these sdk tool for command line, so please do note this url pattern there and here as well)
+  #  after that unzipping those tools and
+  #  then running a series of SDK manager commands to install necessary android SDK packages that'll allow the app to build
   - wget --output-document=$ANDROID_HOME/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip
+
+  #  move the archive to ANDROID_HOME
   - pushd $ANDROID_HOME
   - unzip -d cmdline-tools cmdline-tools.zip
   - popd
   - export PATH=$PATH:${ANDROID_HOME}/cmdline-tools/tools/bin/
+
+  # Nothing fancy here, just checking sdkManager version
   - sdkmanager --version
+
+  # temporarily disable checking for EPIPE error and use yes to accept all licenses
   - set +o pipefail
   - yes | sdkmanager --sdk_root=${ANDROID_HOME} --licenses
   - set -o pipefail
   - sdkmanager --sdk_root=${ANDROID_HOME} "platforms;android-${ANDROID_COMPILE_SDK}"
   - sdkmanager --sdk_root=${ANDROID_HOME} "platform-tools"
   - sdkmanager --sdk_root=${ANDROID_HOME} "build-tools;${ANDROID_BUILD_TOOLS}"
-  - export PATH=$PATH:${ANDROID_HOME}/platform-tools/
+
+  # Not necessary, but just for surity
   - chmod +x ./gradlew
 
+# Basic android and gradle stuff
+
+# Check linting
 lintDebug:
   interruptible: true
   stage: build
   script:
     - ./gradlew -Pci --console=plain :app:lintDebug -PbuildDir=lint
-
+# Make Project
 assembleDebug:
   interruptible: true
   stage: build
@@ -46,12 +81,14 @@ assembleDebug:
       - app/build/outputs/
       - req.json
 
+# Run all tests, if any fails, interrupt the pipeline(fail it)
 debugTests:
   interruptible: true
   stage: test
   script:
     - ./gradlew -Pci --console=plain :app:testDebug
 
+# Deployment to appetize.io, go through readme for more info
 deploy:
   interruptible: true
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,3 @@
-
 # This file is a template, and might need editing before it works on your project.
 # Read more about this script on this blog post https://about.gitlab.com/2018/10/24/setting-up-gitlab-ci-for-android-projects/, by Jason Lenny
 # If you are interested in using Android with FastLane for publishing take a look at the Android-Fastlane template.
@@ -6,25 +5,29 @@
 image: openjdk:8-jdk
 
 variables:
-  ANDROID_COMPILE_SDK: "28"
-  ANDROID_BUILD_TOOLS: "28.0.2"
-  ANDROID_SDK_TOOLS: "4333796"
+  ANDROID_COMPILE_SDK: "29"
+  ANDROID_BUILD_TOOLS: "29.0.3"
+  ANDROID_SDK_TOOLS: "6514223"
 
 before_script:
   - apt-get --quiet update --yes
   - apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1
-  - wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_TOOLS}.zip
-  - unzip -d android-sdk-linux android-sdk.zip
-  - echo y | android-sdk-linux/tools/bin/sdkmanager "platforms;android-${ANDROID_COMPILE_SDK}" >/dev/null
-  - echo y | android-sdk-linux/tools/bin/sdkmanager "platform-tools" >/dev/null
-  - echo y | android-sdk-linux/tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS}" >/dev/null
-  - export ANDROID_HOME=$PWD/android-sdk-linux
-  - export PATH=$PATH:$PWD/android-sdk-linux/platform-tools/
-  - chmod +x ./gradlew
-  # temporarily disable checking for EPIPE error and use yes to accept all licenses
+  - export ANDROID_HOME=${PWD}android-home
+  - install -d $ANDROID_HOME
+  - wget --output-document=$ANDROID_HOME/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip
+  - pushd $ANDROID_HOME
+  - unzip -d cmdline-tools cmdline-tools.zip
+  - popd
+  - export PATH=$PATH:${ANDROID_HOME}/cmdline-tools/tools/bin/
+  - sdkmanager --version
   - set +o pipefail
-  - yes | android-sdk-linux/tools/bin/sdkmanager --licenses
+  - yes | sdkmanager --sdk_root=${ANDROID_HOME} --licenses
   - set -o pipefail
+  - sdkmanager --sdk_root=${ANDROID_HOME} "platforms;android-${ANDROID_COMPILE_SDK}"
+  - sdkmanager --sdk_root=${ANDROID_HOME} "platform-tools"
+  - sdkmanager --sdk_root=${ANDROID_HOME} "build-tools;${ANDROID_BUILD_TOOLS}"
+  - export PATH=$PATH:${ANDROID_HOME}/platform-tools/
+  - chmod +x ./gradlew
 
 lintDebug:
   interruptible: true


### PR DESCRIPTION
**Highlights**
* All the following changes are made for ci/cd in ci file
* Previously, the docker container was using old SDKs for creating environment inside pipelines
* The compileSdk version has been upgraded to the one that is being used in the project(`29`)
* AndroidBuildTools Version has been upgraded to `29.0.3`
* Latest androidSdkTools(`6514223`) are being used now in the container for building, linting and testing
* [This Commit](https://github.com/s-ayush2903/KeepItClean/commit/1e695069988ed74f3daf19fea2fabee7e116a6b5) has a ton of major changes that have been made in the files hierarchy in the sdk archive
* The concerned commit also manipulates few core commands that assist in creating environ
* And finally, documented a ci script(Phew!)
* All pipelines are passing :guitar: 